### PR TITLE
Remove #to_h since the upstream gem fixed the HTTParty issue

### DIFF
--- a/lib/fedex/request/tracking_information.rb
+++ b/lib/fedex/request/tracking_information.rb
@@ -25,7 +25,7 @@ module Fedex
       end
 
       def process_request
-        api_response = self.class.post(api_url, :body => build_xml).to_h
+        api_response = self.class.post(api_url, :body => build_xml)
         puts api_response if @debug == true
         response = parse_response(api_response)
 


### PR DESCRIPTION
The last commit from the jazminschroeder/fedex fixed the issue with HTTParty, so this isn't needed anymore. 