### PR TITLE
Get a better error message when getting rates

### DIFF
--- a/lib/fedex/request/rate.rb
+++ b/lib/fedex/request/rate.rb
@@ -20,7 +20,7 @@ module Fedex
             Fedex::Rate.new(rate_details)
           end
         else
-          raise RateError, error_message(api_response)
+          raise RateError, api_response.to_json
         end
       end
 


### PR DESCRIPTION
# Description
Adds fedex api response to rate error message.

## Issues Resolved

When there's an error getting a rate, there is no information on the error.  

